### PR TITLE
refactored so that submit_done can be used by other python programs

### DIFF
--- a/idonethis.py
+++ b/idonethis.py
@@ -13,13 +13,6 @@ import requests
 
 ROOT_URI = 'https://idonethis.com/api/v0.1/dones/'
 
-parser = argparse.ArgumentParser()
-parser.add_argument('-m', '--message', help='Content of your done')
-parser.add_argument('--team', required=True, help='Your team')
-parser.add_argument('--token', required=True,
-                    help=('Your authorization token: '
-                          'see https://idonethis.com/api/token/'))
-
 
 def get_done_text():
     """Grab input from either the users editor of choice or stdin."""
@@ -41,7 +34,7 @@ def get_done_text():
     return data
 
 
-def submit_done(session, team, done):
+def submit_done(token, team, done):
     """Submit the users done and bask in the glory of productivity.
 
     :param Session session: A `requests_` session object.
@@ -49,6 +42,11 @@ def submit_done(session, team, done):
     :param str done: Description of what was accomplished.
 
     """
+    
+    # Seed the Authorization headers for all subsequent requests
+    session = requests.Session()
+    session.headers['Authorization'] = 'Token {}'.format(token)
+    
     post_data = {'raw_text': done, 'team': team}
     response = session.post(ROOT_URI, json=post_data)
 
@@ -68,20 +66,22 @@ def submit_done(session, team, done):
 
 def main():
     """The main entry point for the application."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m', '--message', help='Content of your done')
+    parser.add_argument('--team', required=True, help='Your team')
+    parser.add_argument('--token', required=True,
+                        help=('Your authorization token: '
+                            'see https://idonethis.com/api/token/'))
     args = parser.parse_args()
     token = args.token
     team = args.team
     done_text = args.message
 
-    # Seed the Authorization headers for all subsequent requests
-    session = requests.Session()
-    session.headers['Authorization'] = 'Token {}'.format(token)
-
     if not done_text:
         done_text = get_done_text()
 
     try:
-        submit_done(session, team, done_text)
+        submit_done(token, team, done_text)
     except Exception as exception:
         sys.exit("Failed to record what you've done: {}".format(exception))
 

--- a/tests.py
+++ b/tests.py
@@ -70,7 +70,7 @@ class TestMainFunction(BetamaxMixn, unittest.TestCase):
 
     @mock.patch('sys.exit')
     @mock.patch('sys.stdin')
-    @mock.patch('idonethis.parser')
+    @mock.patch('idonethis.main.parser')
     @mock.patch('idonethis.requests')
     def test_no_done_text_provided_in_cli(self, requests, parser, stdin, exit_):
         requests.Session.return_value = self.session
@@ -88,7 +88,7 @@ class TestMainFunction(BetamaxMixn, unittest.TestCase):
         self.assertFalse(exit_.called)
 
     @mock.patch('idonethis.requests')
-    @mock.patch('idonethis.parser')
+    @mock.patch('idonethis.main.parser')
     @mock.patch('idonethis.get_done_text')
     def test_done_text_provided_in_cli(self, get_done_text, parser, requests):
         requests.Session.return_value = self.session
@@ -103,7 +103,7 @@ class TestMainFunction(BetamaxMixn, unittest.TestCase):
         self.assertFalse(get_done_text.called)
 
     @mock.patch('sys.exit')
-    @mock.patch('idonethis.parser')
+    @mock.patch('idonethis.main.parser')
     @mock.patch('idonethis.requests')
     def test_unhandled_exception_occurs(self, requests, parser, exit_):
         requests.Session.return_value = self.session


### PR DESCRIPTION
the submit_done function now stands alone a bit more. 

I'd like to be able to call submit_done directly from other python programs that would get the token & team from a config file and generate the message automatically based upon what the program did.

It would be interesting if a config file could be used for this CLI as it is so that the only required item would be the message and not the team and token if those are found in the config file.
